### PR TITLE
fix: global style

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,6 +1,11 @@
 const React = require('react')
 const App = require('./src/WrapApp').default
+const WrapPage = require('./src/WrapPage').default
 
 exports.wrapRootElement = ({ element }) => {
   return <App>{element}</App>
 }
+
+exports.wrapPageElement = ({ props, element }) => (
+  <WrapPage {...props}>{element}</WrapPage>
+)

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -1,6 +1,11 @@
 const React = require('react')
 const App = require('./src/WrapApp').default
+const WrapPage = require('./src/WrapPage').default
 
 exports.wrapRootElement = ({ element }) => {
   return <App>{element}</App>
 }
+
+exports.wrapPageElement = ({ props, element }) => (
+  <WrapPage {...props}>{element}</WrapPage>
+)

--- a/src/WrapApp.tsx
+++ b/src/WrapApp.tsx
@@ -1,18 +1,15 @@
 import { Provider as JotaiProvider } from 'jotai'
 import React, { useRef } from 'react'
 import { QueryClient, QueryClientProvider } from 'react-query'
-import { Slide, ToastContainer } from 'react-toastify'
 import { ThemeProvider } from 'styled-components'
-import BaseLayout from './components/BaseLayout'
-import './fonts.css'
-import GlobalStyle from './GlobalStyle'
 import { EthersProvider } from './libs/ethereum/contexts/useEthers'
 import { Web3Provider as EthereumWeb3Provider } from './libs/ethereum/contexts/useWeb3'
 import { ApiPromiseProvider } from './libs/polkadot/hooks/useApiPromise'
 import { NetworkContextProvider } from './libs/polkadot/hooks/useSubstrateNetwork'
 import { Web3Provider as PolkadotWeb3Provider } from './libs/polkadot/hooks/useWeb3'
-import './ReactToastify.css'
 import theme from './theme'
+import './ReactToastify.css'
+import './fonts.css'
 import './tooltip.css'
 
 const WrapApp: React.FC = ({ children }) => {
@@ -20,7 +17,6 @@ const WrapApp: React.FC = ({ children }) => {
 
   return (
     <ThemeProvider theme={theme}>
-      <GlobalStyle></GlobalStyle>
       <QueryClientProvider client={client.current}>
         <EthereumWeb3Provider>
           <JotaiProvider>
@@ -29,8 +25,7 @@ const WrapApp: React.FC = ({ children }) => {
                 defaultNetwork={process.env.GATSBY_DEFAULT_NETWORK ?? 'khala'}>
                 <ApiPromiseProvider>
                   <PolkadotWeb3Provider originName="ChainBridge Operator">
-                    <BaseLayout>{children}</BaseLayout>
-                    <ToastContainer transition={Slide}></ToastContainer>
+                    {children}
                   </PolkadotWeb3Provider>
                 </ApiPromiseProvider>
               </NetworkContextProvider>

--- a/src/WrapPage.tsx
+++ b/src/WrapPage.tsx
@@ -1,0 +1,13 @@
+import { Slide, ToastContainer } from 'react-toastify'
+import GlobalStyle from './GlobalStyle'
+import BaseLayout from './components/BaseLayout'
+
+const WrapPage: React.FC = ({ children }) => (
+  <>
+    <GlobalStyle></GlobalStyle>
+    <BaseLayout>{children}</BaseLayout>
+    <ToastContainer transition={Slide}></ToastContainer>
+  </>
+)
+
+export default WrapPage


### PR DESCRIPTION
Move `GlobalStyle` and page shared UI components to `wrapPageElement`

Refs:
- https://github.com/gatsbyjs/gatsby/issues/20594
- https://www.gatsbyjs.com/docs/reference/config-files/gatsby-browser/#wrapRootElement